### PR TITLE
Dpop support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven.compiler.plugin.version}</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<compilerArgument>-proc:none</compilerArgument>
 				</configuration>
 			</plugin>

--- a/src/main/java/com/authlete/mkjose/api/jose/GenerateEndpoint.java
+++ b/src/main/java/com/authlete/mkjose/api/jose/GenerateEndpoint.java
@@ -68,7 +68,7 @@ public class GenerateEndpoint
         args.add("--sign");
 
         String[] keys = new String[] {
-                "payload", "signing-alg", "jwk-signing-alg"
+                "payload", "signing-alg", "jwk-signing-alg", "jws-header"
         };
 
         for (String key : keys)

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -15,10 +15,11 @@ class MkJose extends React.Component {
 			payload: '',
 			alg: 'none',
 			jwk: '',
-			payloadMode: 'plain',   // can also be 'ciba' or 'ro' or 'ca'
+			payloadMode: 'plain',   // can also be 'ciba' or 'ro' or 'ca' or 'dpop'
 			output: '',
 			keyLoading: false,
-			joseLoading: false
+			joseLoading: false,
+			jwtHeader: '{}'
 		};
 	}
 	
@@ -33,7 +34,68 @@ class MkJose extends React.Component {
 	}
 	
 	selectTab = (payloadMode) => () => {
-		this.setState({payloadMode: payloadMode});
+		this.setState({payloadMode: payloadMode}, () => {
+			// If DPoP mode is selected, initialize header and payload
+			if (payloadMode === 'dpop') {
+				// Set default algorithm to PS256 for DPoP
+				this.setAlgVal('PS256');
+				
+				// Set default RSA key using existing preset key functionality
+				if (!this.state.jwk) {
+					// Find the SigningKey component's loadPresetKey method via refs isn't available,
+					// so we'll directly call the same logic from the existing loadPresetKey method
+					const defaultRSAKey = {
+						"kty":"RSA",
+						"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
+						"e":"AQAB",
+						"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97IjlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYTCBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLhBOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",
+						"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdiYrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPGBY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",
+						"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxaewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",
+						"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3QCLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",
+						"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-kyNlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",
+						"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2oy26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLUW0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"
+					};
+					this.setKey(JSON.stringify(defaultRSAKey, null, 4));
+				}
+				
+				// Initialize header with DPoP defaults
+				setTimeout(() => {
+					// Use setTimeout to ensure key is set first
+					const defaultHeader = {
+						alg: 'PS256',
+						typ: 'dpop+jwt'
+					};
+					
+					// Add jwk (public key) if we have a key
+					if (this.state.jwk) {
+						try {
+							const privateKey = JSON.parse(this.state.jwk);
+							const publicKey = this.extractPublicKey(privateKey);
+							defaultHeader.jwk = publicKey;
+						} catch (e) {
+							// Invalid key, ignore
+						}
+					}
+					
+					this.setState({jwtHeader: JSON.stringify(defaultHeader, null, 2)});
+				}, 50);
+				
+				// Initialize payload if empty
+				if (!this.state.payload) {
+					const jti = base64url(crypto.getRandomValues(new Uint8Array(32)));
+					const now = Math.floor(Date.now() / 1000);
+					
+					const defaultPayload = {
+						jti: jti,
+						htm: 'POST',
+						htu: 'https://as.authlete.com/token',
+						iat: now
+					};
+					
+					this.setPayload(JSON.stringify(defaultPayload, null, 4));
+				}
+			}
+		});
 	}
 	
 	setAlgEvt = (e) => {
@@ -41,7 +103,74 @@ class MkJose extends React.Component {
 	}
 	
 	setAlgVal = (val) => {
-		this.setState({alg: val});
+		this.setState({alg: val}, () => {
+			this.updateHeaderAlg();
+		});
+	}
+	
+	setJwtHeader = (val) => {
+		this.setState({jwtHeader: val});
+	}
+	
+	updateHeaderAlg = () => {
+		if (this.state.payloadMode === 'dpop') {
+			try {
+				const header = JSON.parse(this.state.jwtHeader);
+				header.alg = this.state.alg;
+				this.setState({jwtHeader: JSON.stringify(header, null, 2)});
+			} catch (e) {
+				// Invalid JSON, ignore
+			}
+		}
+	}
+	
+	updateHeaderJwk = () => {
+		if (this.state.payloadMode === 'dpop' && this.state.jwk) {
+			try {
+				const privateKey = JSON.parse(this.state.jwk);
+				const publicKey = this.extractPublicKey(privateKey);
+				const header = JSON.parse(this.state.jwtHeader);
+				header.jwk = publicKey;
+				this.setState({jwtHeader: JSON.stringify(header, null, 2)});
+			} catch (e) {
+				// Invalid JSON or key, ignore
+			}
+		}
+	}
+	
+	extractPublicKey = (privateKey) => {
+		const publicKey = {
+			kty: privateKey.kty
+		};
+		
+		if (privateKey.kty === 'RSA') {
+			publicKey.n = privateKey.n;
+			publicKey.e = privateKey.e;
+			if (privateKey.alg) publicKey.alg = privateKey.alg;
+			if (privateKey.use) publicKey.use = privateKey.use;
+			if (privateKey.key_ops) publicKey.key_ops = privateKey.key_ops;
+			if (privateKey.kid) publicKey.kid = privateKey.kid;
+		} else if (privateKey.kty === 'EC') {
+			publicKey.crv = privateKey.crv;
+			publicKey.x = privateKey.x;
+			publicKey.y = privateKey.y;
+			if (privateKey.alg) publicKey.alg = privateKey.alg;
+			if (privateKey.use) publicKey.use = privateKey.use;
+			if (privateKey.key_ops) publicKey.key_ops = privateKey.key_ops;
+			if (privateKey.kid) publicKey.kid = privateKey.kid;
+		} else if (privateKey.kty === 'OKP') {
+			publicKey.crv = privateKey.crv;
+			publicKey.x = privateKey.x;
+			if (privateKey.alg) publicKey.alg = privateKey.alg;
+			if (privateKey.use) publicKey.use = privateKey.use;
+			if (privateKey.key_ops) publicKey.key_ops = privateKey.key_ops;
+			if (privateKey.kid) publicKey.kid = privateKey.kid;
+		} else if (privateKey.kty === 'oct') {
+			// For symmetric keys, return the original key (already public)
+			return privateKey;
+		}
+		
+		return publicKey;
 	}
 	
 	setKey = (val) => {
@@ -49,6 +178,7 @@ class MkJose extends React.Component {
 			jwk: val
 		}, () => {
 			this.setAlgForKey();
+			this.updateHeaderJwk();
 		});
 	}
 	
@@ -178,6 +308,11 @@ class MkJose extends React.Component {
 		body.append('signing-alg', this.state.alg);
 		body.append('jwk-signing-alg', this.state.jwk);
 		
+		// Add JWT header if DPoP mode is enabled
+		if (this.state.payloadMode === 'dpop' && this.state.jwtHeader) {
+			body.append('jws-header', this.state.jwtHeader);
+		}
+		
 		this.setState({joseLoading: true});
 		
 		fetch(new Request(url, {
@@ -206,8 +341,14 @@ class MkJose extends React.Component {
 				<Container>
 					<InputForm payload={this.state.payload} payloadMode={this.state.payloadMode} t={this.props.t}
 						setPayload={this.setPayload} selectTab={this.selectTab} clearPayload={this.clearPayload} />
-					<SigningAlg alg={this.state.alg} setAlg={this.setAlgEvt} t={this.props.t} />
-					<SigningKey jwk={this.state.jwk} alg={this.state.alg} keyLoading={this.keyLoading} t={this.props.t} 
+					{this.state.payloadMode === 'dpop' && (
+						<HeaderForm 
+							jwtHeader={this.state.jwtHeader}
+							setJwtHeader={this.setJwtHeader}
+							t={this.props.t} />
+					)}
+					<SigningAlg alg={this.state.alg} setAlg={this.setAlgEvt} payloadMode={this.state.payloadMode} t={this.props.t} />
+					<SigningKey jwk={this.state.jwk} alg={this.state.alg} keyLoading={this.keyLoading} payloadMode={this.state.payloadMode} t={this.props.t} 
 						setKey={this.setKey} clearKey={this.clearKey} callMkJwk={this.callMkJwk} />
 					<GenerateButton generate={this.generate} t={this.props.t} />
 				</Container>
@@ -239,6 +380,10 @@ const InputForm = ({...props}) => {
 		label = props.t('input_form.payload_ca');
 		payload = <ClientAssertionPayload payload={props.payload}
 			setPayload={props.setPayload} t={props.t} />;
+	} else if (props.payloadMode == 'dpop') {
+		label = 'DPoP JWT Payload';
+		payload = <DpopPayload payload={props.payload}
+			setPayload={props.setPayload} t={props.t} />;
 	}
 	return (
 		<>
@@ -268,6 +413,10 @@ const InputForm = ({...props}) => {
 							<Tabs.Tab active={props.payloadMode == 'ca'} onClick={props.selectTab('ca')}>
 								<span className="is-hidden-touch">{props.t('input_form.tabs.desktop.ca')}</span>
 								<span className="is-hidden-desktop">{props.t('input_form.tabs.mobile.ca')}</span>
+							</Tabs.Tab>
+							<Tabs.Tab active={props.payloadMode == 'dpop'} onClick={props.selectTab('dpop')}>
+								<span className="is-hidden-touch">DPoP JWT</span>
+								<span className="is-hidden-desktop">DPoP</span>
 							</Tabs.Tab>
 						</Tabs>
 					</Level.Item>
@@ -814,15 +963,17 @@ class ClientAssertionPayload extends React.Component {
 }
 
 const SigningAlg = ({...props}) => {
+	const isDPoPMode = props.payloadMode === 'dpop';
+	
 	return (
 		<Form.Field>
 			<Form.Label className="is-medium">{props.t('signing_alg.label')}</Form.Label>
 			<Form.Control>
 				<Form.Select onChange={props.setAlg} value={props.alg || ''}>
-	                <option value="none">{props.t('signing_alg.none')}</option>
-	                <option value="HS256">{props.t('signing_alg.HS256')}</option>
-	                <option value="HS384">{props.t('signing_alg.HS384')}</option>
-	                <option value="HS512">{props.t('signing_alg.HS512')}</option>
+					{!isDPoPMode && <option value="none">{props.t('signing_alg.none')}</option>}
+					{!isDPoPMode && <option value="HS256">{props.t('signing_alg.HS256')}</option>}
+					{!isDPoPMode && <option value="HS384">{props.t('signing_alg.HS384')}</option>}
+					{!isDPoPMode && <option value="HS512">{props.t('signing_alg.HS512')}</option>}
 	                <option value="RS256">{props.t('signing_alg.RS256')}</option>
 	                <option value="RS384">{props.t('signing_alg.RS384')}</option>
 	                <option value="RS512">{props.t('signing_alg.RS512')}</option>
@@ -836,6 +987,11 @@ const SigningAlg = ({...props}) => {
 	                <option value="EdDSA">{props.t('signing_alg.EdDSA')}</option>
 				</Form.Select>
 			</Form.Control>
+			{isDPoPMode && (
+				<Form.Help color="info">
+					DPoP requires asymmetric key algorithms (RSA, ECDSA, EdDSA)
+				</Form.Help>
+			)}
 		</Form.Field>
 	);
 }
@@ -933,6 +1089,8 @@ class SigningKey extends React.Component {
 	}
 	
 	render() {
+		const isDPoPMode = this.props.payloadMode === 'dpop';
+		
 		return (
 		<>
 			<Level>
@@ -953,9 +1111,11 @@ class SigningKey extends React.Component {
 							<Tabs.Tab active={this.state.keyGen == 'generate'} onClick={this.selectTab('generate')}>
 							{this.props.t('signing_key.generated')}
 							</Tabs.Tab>
-							<Tabs.Tab active={this.state.keyGen == 'shared'} onClick={this.selectTab('shared')}>
-							{this.props.t('signing_key.shared')}
-							</Tabs.Tab>
+							{!isDPoPMode && (
+								<Tabs.Tab active={this.state.keyGen == 'shared'} onClick={this.selectTab('shared')}>
+								{this.props.t('signing_key.shared')}
+								</Tabs.Tab>
+							)}
 						</Tabs>
 					</Level.Item>
 					<Level.Item>
@@ -975,7 +1135,7 @@ class SigningKey extends React.Component {
 							{this.state.keyGen == 'preset' ? this.props.t('signing_key.load') : this.props.t('signing_key.generate')}
 							<Button onClick={this.genKey('RSA')}>{this.props.t('signing_key.rsa')}</Button>
 							<Button onClick={this.genKey('EC')}>{this.props.t('signing_key.ec')}</Button>
-							<Button onClick={this.genKey('oct')}>{this.props.t('signing_key.oct')}</Button>
+							{!isDPoPMode && <Button onClick={this.genKey('oct')}>{this.props.t('signing_key.oct')}</Button>}
 							<Button onClick={this.genKey('OKP')}>{this.props.t('signing_key.okp')}</Button>
 						</Level.Item>
 					</Level.Side>
@@ -983,7 +1143,7 @@ class SigningKey extends React.Component {
 			)}
 			<Form.Field>
 				<Form.Control loading={this.props.keyLoading}>
-					{ this.state.keyGen == 'shared' && (
+					{ this.state.keyGen == 'shared' && !isDPoPMode && (
 						<Form.Input className="has-background-light has-text-primary" type="text" placeholder={this.props.t('signing_key.shared_secret')} onChange={this.setShared} value={this.getShared(this.props.jwk)} />
 					)}
 
@@ -1061,6 +1221,266 @@ class LanguageSwitch extends React.Component {
 			</Tabs.Tab>
 	</Tabs>
 );
+	}
+}
+
+const HeaderForm = ({...props}) => {
+	const clearHeader = () => {
+		props.setJwtHeader('{}');
+	};
+
+	return (
+		<>
+			<Level>
+				<Level.Side align="left">
+					<Level.Item>
+						<Form.Field>
+							<Form.Label className="is-medium">JWT Header</Form.Label>
+						</Form.Field>
+					</Level.Item>
+				</Level.Side>
+				<Level.Side align="right">
+					<Level.Item>
+						<Button onClick={clearHeader}><i className="far fa-trash-alt"></i></Button>
+					</Level.Item>
+				</Level.Side>
+			</Level>
+			<Form.Field>
+				<Form.Control>
+					<Form.Textarea 
+						rows={8} 
+						spellCheck={false} 
+						value={props.jwtHeader}
+						onChange={(e) => props.setJwtHeader(e.target.value)}
+						placeholder='{"alg": "ES256", "typ": "dpop+jwt", "jwk": {...}}'
+					/>
+				</Form.Control>
+			</Form.Field>
+		</>
+	);
+};
+
+class DpopPayload extends React.Component {
+	constructor(props) {
+		super(props);
+		
+		var p = {};
+		try {
+			p = JSON.parse(props.payload);	
+		} catch (e) {
+			// non-json payload, ignore
+		}
+		
+		// Generate default DPoP payload
+		if (Object.keys(p).length === 0) {
+			p = this.generateDefaultPayload();
+		}
+		
+		var arbString = '';
+		var customFields = {};
+		
+		// Separate default fields from custom fields
+		const defaultFields = ['jti', 'htm', 'htu', 'iat'];
+		Object.keys(p).forEach((field) => {
+			if (!defaultFields.includes(field)) {
+				customFields[field] = p[field];
+			}
+		});
+		
+		if (Object.keys(customFields).length > 0) {
+			arbString = JSON.stringify(customFields, null, 4);
+		} else {
+			// Initialize with default nbf and exp in arbitrary fields
+			const now = Math.floor(Date.now() / 1000);
+			const defaultArbitrary = {
+				nbf: now,
+				exp: now + 600
+			};
+			arbString = JSON.stringify(defaultArbitrary, null, 4);
+		}
+		
+		this.state = {
+			payload: p,
+			arbString: arbString
+		};
+	}
+	
+	componentDidUpdate(prevProps) {
+		if (!!prevProps.payload && !this.props.payload) {
+			this.setState({
+				payload: this.generateDefaultPayload(),
+				arbString: ''
+			});
+		}
+	}
+
+	defaultFields = ['jti', 'htm', 'htu', 'iat'];
+
+	generateDefaultPayload = () => {
+		// Generate random JTI (32 bytes base64url encoded)
+		const jti = base64url(crypto.getRandomValues(new Uint8Array(32)));
+		const now = Math.floor(Date.now() / 1000);
+		
+		return {
+			jti: jti,
+			htm: 'POST',
+			htu: 'https://as.authlete.com/token',
+			iat: now
+		};
+	};
+	
+	fieldTypes = {
+		jti: 'text',
+		htm: 'text',
+		htu: 'text',
+		iat: 'number'
+	}
+
+	setPayloadItem = (field) => (e) => {
+		var p = this.state.payload;
+		var val = e.target.value;
+		var type = e.target.attributes["type"].value;
+				
+		if (type == 'number') {
+			val = Number(val);
+		}
+		
+		p[field] = val;
+		
+		if (!val && type == 'number') {
+			delete p[field];
+		}
+
+		this.updatePayload(p);
+	}
+	
+	clearPayloadItem = (field) => (e) => {
+		var p = this.state.payload;
+		p[field] = undefined;
+		
+		this.updatePayload(p);
+	}
+
+	setArbitrary = (e) => {
+		const val = e.target.value;
+		
+		try {
+			if (val) {
+				const arbFields = JSON.parse(val);
+				var p = {};
+				
+				// Copy default fields
+				this.defaultFields.forEach((field) => {
+					if (this.state.payload[field] !== undefined) {
+						p[field] = this.state.payload[field];
+					}
+				});
+				
+				// Add arbitrary fields
+				Object.keys(arbFields).forEach((field) => {
+					p[field] = arbFields[field];
+				});
+				
+				this.updatePayload(p);
+			}
+		} catch (e) {
+			// Invalid JSON, ignore
+		}
+		
+		this.setState({ arbString: val });
+	}
+
+	clearArbitrary = () => {
+		var p = {};
+		// Keep only default fields
+		this.defaultFields.forEach((field) => {
+			if (this.state.payload[field] !== undefined) {
+				p[field] = this.state.payload[field];
+			}
+		});
+		
+		this.updatePayload(p);
+		this.setState({ arbString: '' });
+	}
+
+	updatePayload = (p) => {
+		this.props.setPayload(JSON.stringify(p, null, 4));
+		this.setState({ payload: p });
+	}
+
+	generateNewJti = () => {
+		const jti = base64url(crypto.getRandomValues(new Uint8Array(32)));
+		this.setPayloadItem('jti')({target: {value: jti, attributes: {type: {value: 'text'}}}});
+	}
+
+	setCurrentTime = () => {
+		const now = Math.floor(Date.now() / 1000);
+		this.setPayloadItem('iat')({target: {value: now, attributes: {type: {value: 'number'}}}});
+	}
+
+	
+	render() {
+		const fields = [];
+		
+		// Render default fields
+		this.defaultFields.forEach((field) => {
+			const isJti = field === 'jti';
+			const isIat = field === 'iat';
+			
+			fields.push(
+				<tr key={'dpop-' + field}>
+					<td><code>{field}</code></td>
+					<td>
+						<input 
+							id={'dpop-' + field} 
+							type={this.fieldTypes[field]} 
+							size={60} 
+							onChange={this.setPayloadItem(field)} 
+							value={this.state.payload[field] || ''} 
+						/>
+						{isJti && (
+							<Button size="small" onClick={this.generateNewJti} style={{marginLeft: '8px'}}>
+								Generate
+							</Button>
+						)}
+						{isIat && (
+							<Button size="small" onClick={this.setCurrentTime} style={{marginLeft: '8px'}}>
+								Now
+							</Button>
+						)}
+					</td>
+					<td><Button onClick={this.clearPayloadItem(field)}><i className="far fa-trash-alt"></i></Button></td>
+				</tr>
+			);
+		});
+		
+		return (
+			<Card color="light">
+				<Card.Content>
+					<div className="table-container">
+						<Table>
+							<tbody>
+								{fields}
+								<tr>
+									<td>Arbitrary JSON</td>
+									<td>
+										<Form.Textarea 
+											rows={5} 
+											cols={50} 
+											spellCheck="false"
+											placeholder='{"nbf": 1234567890, "exp": 1234568490, "custom_field": "value"}'
+											onChange={this.setArbitrary} 
+											value={this.state.arbString} 
+										/>
+									</td>
+									<td><Button onClick={this.clearArbitrary}><i className="far fa-trash-alt"></i></Button></td>
+								</tr>
+							</tbody>
+						</Table>
+					</div>
+				</Card.Content>
+			</Card>
+		);
 	}
 }
 

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -381,7 +381,7 @@ const InputForm = ({...props}) => {
 		payload = <ClientAssertionPayload payload={props.payload}
 			setPayload={props.setPayload} t={props.t} />;
 	} else if (props.payloadMode == 'dpop') {
-		label = 'DPoP JWT Payload';
+		label = props.t('input_form.payload_dpop');
 		payload = <DpopPayload payload={props.payload}
 			setPayload={props.setPayload} t={props.t} />;
 	}
@@ -1235,7 +1235,7 @@ const HeaderForm = ({...props}) => {
 				<Level.Side align="left">
 					<Level.Item>
 						<Form.Field>
-							<Form.Label className="is-medium">JWT Header</Form.Label>
+							<Form.Label className="is-medium">{props.t('dpop.jwt_header')}</Form.Label>
 						</Form.Field>
 					</Level.Item>
 				</Level.Side>
@@ -1637,7 +1637,7 @@ class DpopPayload extends React.Component {
 							<tbody>
 								{fields}
 								<tr>
-									<td>Arbitrary JSON</td>
+									<td>{this.props.t('dpop.arbitrary')}</td>
 									<td>
 										<Form.Textarea 
 											rows={5} 

--- a/src/main/js/i18n.js
+++ b/src/main/js/i18n.js
@@ -10,12 +10,14 @@ const resources = {
 					payload_ro: 'Payload for Request Object',
 					payload_ciba: 'Payload for Backchannel Authentication Request',
 					payload_ca: 'Payload for Client Assertion',
+					payload_dpop: 'Payload for DPoP JWT',
 					tabs: {
 						desktop: {
 							plain: 'Plain',
 							ciba: 'CIBA',
 							ro: 'Request Object',
 							ca: 'Client Assertion',
+							dpop: 'DPoP JWT',
 						},
 						mobile: {
 							plain: 'Plain',
@@ -30,6 +32,10 @@ const resources = {
 				},
 				ca: {
 					arbitrary: 'Arbitrary JSON'
+				},
+				dpop: {
+					arbitrary: 'Arbitrary JSON',
+					jwt_header: 'DPoP JWT Header'
 				},
 				signing_alg: {
 					label: 'Signing Algorithm',
@@ -86,12 +92,14 @@ const resources = {
 					payload_ro: 'リクエストオブジェクト用ペイロード',
 					payload_ciba: 'バックチャネル認証リクエスト用ペイロード',
 					payload_ca: 'クライアントアサーション用ペイロード',
+					payload_dpop: 'DPoP JWT 用ペイロード',
 					tabs: {
 						desktop: {
 							plain: '直接入力',
 							ciba: 'CIBA',
 							ro: 'リクエストオブジェクト',
 							ca: 'クライアントアサーション',
+							dpop: 'DPoP JWT'
 						}
 					}
 				},
@@ -100,6 +108,10 @@ const resources = {
 				},
 				ca: {
 					arbitrary: '任意の JSON'
+				},
+				dpop: {
+					arbitrary: '任意の JSON',
+					jwt_header: 'DPoP JWT ヘッダー'
 				},
 				signing_alg: {
 					label: '署名アルゴリズム',


### PR DESCRIPTION
## Background  

When creating automated tests or sample requests for the Authlete API in **Postman** or the **VS Code rest‑client**, we need to generate JWTs on the fly.  
For example **DPoP** and **Verifiable Credential (VC) proofs**, the JWT *header* must include special claims such as `typ:"dpop+jwt"`, `jwk`.  However, **mkjose.org** silently ignored the `jws-header` field and did not pass it to the backend.

This PR:

1. **Fixes the backend** so it correctly processes the `jws-header` parameter.  
2. Adds a **frontend UI** section to generate the most common type of header‑rich token: a **DPoP JWT**.

## Overview  

* Provides first‑class **Demonstration of Proof‑of‑Possession (DPoP)** support.  
* Adds a `jws-header` option so callers can inject *any* JSON header into a JWT.  
* Raises the Java compiler level to 1.8.

## Changes

| Component | Change | Purpose / Reason |
|-----------|--------|------------------|
| **GenerateEndpoint** | Accepts new request parameter `jws-header`; CLI flag `--jws-header` added | Allows callers to set `typ`, `kid`, `jwk` etc for jwt header claims. |
| **DPoP support** | Auto‑generates `htu`, `htm`, `jti`, `iat`; adds UI form for DPoP generation | One‑click, RFC 9449‑compliant DPoP proof creation |

### Example

The following curl sample is how to create DPoP JWT Proof using mkjose.org. Please note that the jose-header is specified, which causes the jwk claim to be added to the header.

```
curl --request POST \
  --url http://localhost:8080/api/jose/generate \
  --header 'content-type: application/x-www-form-urlencoded;charset=UTF-8' \
  --data 'payload=%7B%22htu%22:%22https://api.dev2.haniyama.com/api/service/get/list%22,%22htm%22:%22GET%22,%22iat%22:1753343133%20%20%20%20%20%20%20%20%20%20%20%20#%20%E7%8F%BE%E5%9C%A8%E3%81%AE%20Unix%20%E3%82%A8%E3%83%9D%E3%83%83%E3%82%AF%E7%A7%92,%22nbf%22:1753343133%20%20%20%20%20%20%20%20%20%20%20%20#%20%E7%8F%BE%E5%9C%A8%E3%81%AE%20Unix%20%E3%82%A8%E3%83%9D%E3%83%83%E3%82%AF%E7%A7%92,%22exp%22:1753346733%20%20%20%20%20%20%20%20#%201%E6%99%82%E9%96%93%E5%BE%8C%E3%81%AE%20Unix%20%E3%82%A8%E3%83%9D%E3%83%83%E3%82%AF%E7%A7%92,%22jti%22:%22%7B%7B$uuid%7D%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20#%20%E3%83%A9%E3%83%B3%E3%83%80%E3%83%A0%20UUID%22%7D&signing-alg=ES256&jwk-signing-alg=%7B%22kty%22:%22EC%22,%22d%22:%22K-23JuEk56YFjpwn0ZNEHDLmAxO2Sqekoo5fXBqBy1Y%22,%22crv%22:%22P-256%22,%22x%22:%229wRw5YCQyLLUnxJni7OlX_pnKq6vMI9wCZsZwUnRm6w%22,%22y%22:%22Fx2OtvDMKleotXyR6oFX9S5p7h2RVrlfzumDkjNMatI%22%7D&jws-header=%7B%22alg%22:%22ES256%22,%22typ%22:%22dpop+jwt%22,%22jwk%22:%7B%22kty%22:%22EC%22,%22crv%22:%22P-256%22,%22x%22:%229wRw5YCQyLLUnxJni7OlX_pnKq6vMI9wCZsZwUnRm6w%22,%22y%22:%22Fx2OtvDMKleotXyR6oFX9S5p7h2RVrlfzumDkjNMatI%22%7D%7D'
```

### New UI for DPoP JWT
<img width="1905" height="2466" alt="image" src="https://github.com/user-attachments/assets/5177a1e0-3ed5-4e45-acf7-309c16eaa051" />

